### PR TITLE
gh-122: Fixed path to zenodo

### DIFF
--- a/tutorials/likelihood/spectroscopic_likelihoods.ipynb
+++ b/tutorials/likelihood/spectroscopic_likelihoods.ipynb
@@ -77,18 +77,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mps_GCspectro_comet_EFT_z1..fits downloaded successfully\n",
-      "mps_GCspectro_comet_EFT_z1.2.fits downloaded successfully\n",
-      "mps_GCspectro_comet_EFT_z1.4.fits downloaded successfully\n",
-      "mps_GCspectro_comet_EFT_z1.65.fits downloaded successfully\n",
-      "cov_Gauss_GCspectro_comet_EFT_z1.2_2500deg2.fits downloaded successfully\n",
-      "cov_Gauss_GCspectro_comet_EFT_z1.4_2500deg2.fits downloaded successfully\n",
-      "cov_Gauss_GCspectro_comet_EFT_z1.65_2500deg2.fits downloaded successfully\n",
-      "cov_Gauss_GCspectro_comet_EFT_z1._2500deg2.fits downloaded successfully\n",
-      "mixmat_GCspectro_identity_z1..fits downloaded successfully\n",
-      "mixmat_GCspectro_identity_z1.2.fits downloaded successfully\n",
-      "mixmat_GCspectro_identity_z1.4.fits downloaded successfully\n",
-      "mixmat_GCspectro_identity_z1.65.fits downloaded successfully\n"
+      "mps_pk_GCspectro_comet_EFT_z1..fits downloaded successfully\n",
+      "mps_pk_GCspectro_comet_EFT_z1.2.fits downloaded successfully\n",
+      "mps_pk_GCspectro_comet_EFT_z1.4.fits downloaded successfully\n",
+      "mps_pk_GCspectro_comet_EFT_z1.65.fits downloaded successfully\n",
+      "cov_pk_Gauss_GCspectro_comet_EFT_z1.2_2500deg2.fits downloaded successfully\n",
+      "cov_pk_Gauss_GCspectro_comet_EFT_z1.4_2500deg2.fits downloaded successfully\n",
+      "cov_pk_Gauss_GCspectro_comet_EFT_z1.65_2500deg2.fits downloaded successfully\n",
+      "cov_pk_Gauss_GCspectro_comet_EFT_z1._2500deg2.fits downloaded successfully\n",
+      "mixmat_pk_GCspectro_identity_z1..fits downloaded successfully\n",
+      "mixmat_pk_GCspectro_identity_z1.2.fits downloaded successfully\n",
+      "mixmat_pk_GCspectro_identity_z1.4.fits downloaded successfully\n",
+      "mixmat_pk_GCspectro_identity_z1.65.fits downloaded successfully\n"
      ]
     }
    ],
@@ -102,18 +102,18 @@
     "    \n",
     "    # URLs of the files to be downloaded\n",
     "    urls = {\n",
-    "        \"mps_GCspectro_comet_EFT_z1..fits\": \"https://zenodo.org/records/18678898/files/mps_GCspectro_comet_EFT_z1..fits\",\n",
-    "        \"mps_GCspectro_comet_EFT_z1.2.fits\": \"https://zenodo.org/records/18678898/files/mps_GCspectro_comet_EFT_z1.2.fits\",\n",
-    "        \"mps_GCspectro_comet_EFT_z1.4.fits\": \"https://zenodo.org/records/18678898/files/mps_GCspectro_comet_EFT_z1.4.fits\",\n",
-    "        \"mps_GCspectro_comet_EFT_z1.65.fits\": \"https://zenodo.org/records/18678898/files/mps_GCspectro_comet_EFT_z1.65.fits\",\n",
-    "        \"cov_Gauss_GCspectro_comet_EFT_z1.2_2500deg2.fits\": \"https://zenodo.org/records/18678898/files/cov_Gauss_GCspectro_comet_EFT_z1.2_2500deg2.fits\",\n",
-    "        \"cov_Gauss_GCspectro_comet_EFT_z1.4_2500deg2.fits\": \"https://zenodo.org/records/18678898/files/cov_Gauss_GCspectro_comet_EFT_z1.4_2500deg2.fits\",\n",
-    "        \"cov_Gauss_GCspectro_comet_EFT_z1.65_2500deg2.fits\": \"https://zenodo.org/records/18678898/files/cov_Gauss_GCspectro_comet_EFT_z1.65_2500deg2.fits\",\n",
-    "        \"cov_Gauss_GCspectro_comet_EFT_z1._2500deg2.fits\": \"https://zenodo.org/records/18678898/files/cov_Gauss_GCspectro_comet_EFT_z1._2500deg2.fits\",\n",
-    "        \"mixmat_GCspectro_identity_z1..fits\": \"https://zenodo.org/records/18678898/files/mixmat_GCspectro_identity_z1..fits\",\n",
-    "        \"mixmat_GCspectro_identity_z1.2.fits\": \"https://zenodo.org/records/18678898/files/mixmat_GCspectro_identity_z1.2.fits\",\n",
-    "        \"mixmat_GCspectro_identity_z1.4.fits\": \"https://zenodo.org/records/18678898/files/mixmat_GCspectro_identity_z1.4.fits\",\n",
-    "        \"mixmat_GCspectro_identity_z1.65.fits\": \"https://zenodo.org/records/18678898/files/mixmat_GCspectro_identity_z1.65.fits\",\n",
+    "        \"mps_pk_GCspectro_comet_EFT_z1..fits\": \"https://zenodo.org/records/18711304/files/mps_pk_GCspectro_comet_EFT_z1..fits\",\n",
+    "        \"mps_pk_GCspectro_comet_EFT_z1.2.fits\": \"https://zenodo.org/records/18711304/files/mps_pk_GCspectro_comet_EFT_z1.2.fits\",\n",
+    "        \"mps_pk_GCspectro_comet_EFT_z1.4.fits\": \"https://zenodo.org/records/18711304/files/mps_pk_GCspectro_comet_EFT_z1.4.fits\",\n",
+    "        \"mps_pk_GCspectro_comet_EFT_z1.65.fits\": \"https://zenodo.org/records/18711304/files/mps_pk_GCspectro_comet_EFT_z1.65.fits\",\n",
+    "        \"cov_pk_Gauss_GCspectro_comet_EFT_z1.2_2500deg2.fits\": \"https://zenodo.org/records/18711304/files/cov_pk_Gauss_GCspectro_comet_EFT_z1.2_2500deg2.fits\",\n",
+    "        \"cov_pk_Gauss_GCspectro_comet_EFT_z1.4_2500deg2.fits\": \"https://zenodo.org/records/18711304/files/cov_pk_Gauss_GCspectro_comet_EFT_z1.4_2500deg2.fits\",\n",
+    "        \"cov_pk_Gauss_GCspectro_comet_EFT_z1.65_2500deg2.fits\": \"https://zenodo.org/records/18711304/files/cov_pk_Gauss_GCspectro_comet_EFT_z1.65_2500deg2.fits\",\n",
+    "        \"cov_pk_Gauss_GCspectro_comet_EFT_z1._2500deg2.fits\": \"https://zenodo.org/records/18711304/files/cov_pk_Gauss_GCspectro_comet_EFT_z1._2500deg2.fits\",\n",
+    "        \"mixmat_pk_GCspectro_identity_z1..fits\": \"https://zenodo.org/records/18711304/files/mixmat_pk_GCspectro_identity_z1..fits\",\n",
+    "        \"mixmat_pk_GCspectro_identity_z1.2.fits\": \"https://zenodo.org/records/18711304/files/mixmat_pk_GCspectro_identity_z1.2.fits\",\n",
+    "        \"mixmat_pk_GCspectro_identity_z1.4.fits\": \"https://zenodo.org/records/18711304/files/mixmat_pk_GCspectro_identity_z1.4.fits\",\n",
+    "        \"mixmat_pk_GCspectro_identity_z1.65.fits\": \"https://zenodo.org/records/18711304/files/mixmat_pk_GCspectro_identity_z1.65.fits\",\n",
     "    }\n",
     "    \n",
     "    # Function to download a file\n",
@@ -164,13 +164,13 @@
     "labels = [str(z).strip('0') for z in redshifts]\n",
     "\n",
     "# This uses the functionality of euclidlib of reading multiple files at the same time\n",
-    "filename = 'mps_GCspectro_comet_EFT_z{}.fits'\n",
+    "filename = 'mps_pk_GCspectro_comet_EFT_z{}.fits'\n",
     "datavec = get_PowerSpectrumMultipoles(filename, *labels)\n",
     "\n",
-    "filename = 'cov_Gauss_GCspectro_comet_EFT_z{}_2500deg2.fits'\n",
+    "filename = 'cov_pk_Gauss_GCspectro_comet_EFT_z{}_2500deg2.fits'\n",
     "covariance = get_PowerSpectrumMultipolesCovariance(filename, *labels)\n",
     "\n",
-    "filename = 'mixmat_GCspectro_identity_z{}.fits'\n",
+    "filename = 'mixmat_pk_GCspectro_identity_z{}.fits'\n",
     "mixing = get_PowerSpectrumMultipolesMixingMatrix(filename, *labels)\n",
     "\n",
     "# The data dictionary is what must be passed as input to the likelihood class\n",
@@ -296,7 +296,7 @@
      "text": [
       "🔍 Timing log-likelihood initialisation for spectroscopic GC:\n",
       "✅ Spectroscopic GC likelihood initialised.\n",
-      "⏱️ Time elapsed: 0.016 seconds\n"
+      "⏱️ Time elapsed: 0.041 seconds\n"
      ]
     }
    ],
@@ -341,7 +341,7 @@
       "⏱️ Timing log-likelihood evaluation:\n",
       "Log-likelihood: -2.465878570882564e-06\n",
       "-2 * log-likelihood: 4.931757141765128e-06\n",
-      "⏱️ Time elapsed: 0.140 seconds\n"
+      "⏱️ Time elapsed: 0.174 seconds\n"
      ]
     }
    ],
@@ -993,7 +993,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Computing likelihood: 100%|███████████████████| 200/200 [00:04<00:00, 43.71it/s]\n"
+      "Computing likelihood: 100%|███████████████████| 200/200 [00:04<00:00, 45.10it/s]\n"
      ]
     },
     {


### PR DESCRIPTION
## 📌 Related Issue
Closes #122 

## ✨ What’s been added or changed?
The likelihood notebook now correctly target the correct path on zenodo (v4)

- [x] I've named the title of this pull request starting by 'gh-#: TITLE'
- [x] I’ve linked the related issue  
- [x] I’ve tested the code or notebooks manually  
- [ ] I’ve added comments/docstrings where needed (i.e: README)
- [ ] I’ve updated relevant docs if necessary  
