### PR TITLE
gh-127: Update photo.ipynb to include n(z) stretches

### DIFF
--- a/tutorials/observables/photo.ipynb
+++ b/tutorials/observables/photo.ipynb
@@ -2,25 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/HMcode2020Emu\n",
-      "Loading linear emulator...\n",
-      "Linear emulator loaded in memory.\n",
-      "Loading nonlinear emulator...\n",
-      "Non-linear emulator loaded in memory.\n",
-      "Loading linear emulator...\n",
-      "Baryonic boost emulator loaded in memory.\n",
-      "Loading sigma8 emulator...\n",
-      "Linear emulator loaded in memory.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# General imports\n",
     "import numpy as np\n",
@@ -63,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -143,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -245,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +248,10 @@
     "                                              'magnification_bias_5': 0.0, 'magnification_bias_6': 0.0,\n",
     "                                              'dz_pos_1': 0.0, 'dz_pos_2': 0.0,\n",
     "                                              'dz_pos_3': 0.0, 'dz_pos_4': 0.0,\n",
-    "                                              'dz_pos_5': 0.0, 'dz_pos_6': 0.0})\n",
+    "                                              'dz_pos_5': 0.0, 'dz_pos_6': 0.0,\n",
+    "                                              'width_pos_1': 1.0, 'width_pos_2': 1.0,\n",
+    "                                              'width_pos_3': 1.0, 'width_pos_4': 1.0,\n",
+    "                                              'width_pos_5': 1.0, 'width_pos_6': 1.0})\n",
     "\n",
     "tracer_she = ShearTracer(perturbations=perturbations, \n",
     "                             dndz=my_dndz_she_norm,\n",
@@ -275,12 +262,15 @@
     "                                              'multiplicative_bias_5': 0.0, 'multiplicative_bias_6': 0.0,\n",
     "                                              'dz_shear_1': 0.0, 'dz_shear_2': 0.0,\n",
     "                                              'dz_shear_3': 0.0, 'dz_shear_4': 0.0,\n",
-    "                                              'dz_shear_5': 0.0, 'dz_shear_6': 0.0})"
+    "                                              'dz_shear_5': 0.0, 'dz_shear_6': 0.0,\n",
+    "                                              'width_shear_1': 1.0, 'width_shear_2': 1.0,\n",
+    "                                              'width_shear_3': 1.0, 'width_shear_4': 1.0,\n",
+    "                                              'width_shear_5': 1.0, 'width_shear_6': 1.0})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -356,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -400,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -425,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -459,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,64 +472,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:417: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  C_ell_out[key] = mixing_matrix[key].array @ C_ell_calc[key].array\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:417: RuntimeWarning: overflow encountered in matmul\n",
-      "  C_ell_out[key] = mixing_matrix[key].array @ C_ell_calc[key].array\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:417: RuntimeWarning: invalid value encountered in matmul\n",
-      "  C_ell_out[key] = mixing_matrix[key].array @ C_ell_calc[key].array\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:433: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  mixing_matrix[key].array[0] @ C_ell_calc[key].array[0, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:433: RuntimeWarning: overflow encountered in matmul\n",
-      "  mixing_matrix[key].array[0] @ C_ell_calc[key].array[0, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:433: RuntimeWarning: invalid value encountered in matmul\n",
-      "  mixing_matrix[key].array[0] @ C_ell_calc[key].array[0, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:434: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  + mixing_matrix[key].array[1] @ C_ell_calc[key].array[1, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:434: RuntimeWarning: overflow encountered in matmul\n",
-      "  + mixing_matrix[key].array[1] @ C_ell_calc[key].array[1, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:434: RuntimeWarning: invalid value encountered in matmul\n",
-      "  + mixing_matrix[key].array[1] @ C_ell_calc[key].array[1, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:438: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  mixing_matrix[key].array[2] @ C_ell_calc[key].array[0, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:438: RuntimeWarning: overflow encountered in matmul\n",
-      "  mixing_matrix[key].array[2] @ C_ell_calc[key].array[0, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:438: RuntimeWarning: invalid value encountered in matmul\n",
-      "  mixing_matrix[key].array[2] @ C_ell_calc[key].array[0, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:442: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  mixing_matrix[key].array[2] @ C_ell_calc[key].array[1, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:442: RuntimeWarning: overflow encountered in matmul\n",
-      "  mixing_matrix[key].array[2] @ C_ell_calc[key].array[1, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:442: RuntimeWarning: invalid value encountered in matmul\n",
-      "  mixing_matrix[key].array[2] @ C_ell_calc[key].array[1, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:446: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  mixing_matrix[key].array[0] @ C_ell_calc[key].array[1, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:446: RuntimeWarning: overflow encountered in matmul\n",
-      "  mixing_matrix[key].array[0] @ C_ell_calc[key].array[1, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:446: RuntimeWarning: invalid value encountered in matmul\n",
-      "  mixing_matrix[key].array[0] @ C_ell_calc[key].array[1, 1]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:447: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  + mixing_matrix[key].array[1] @ C_ell_calc[key].array[0, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:447: RuntimeWarning: overflow encountered in matmul\n",
-      "  + mixing_matrix[key].array[1] @ C_ell_calc[key].array[0, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:447: RuntimeWarning: invalid value encountered in matmul\n",
-      "  + mixing_matrix[key].array[1] @ C_ell_calc[key].array[0, 0]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:407: RuntimeWarning: divide by zero encountered in matmul\n",
-      "  mixing_matrix[(\"POS\", \"SHE\", a, b)]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:407: RuntimeWarning: overflow encountered in matmul\n",
-      "  mixing_matrix[(\"POS\", \"SHE\", a, b)]\n",
-      "/Users/guadalupecanasherrera/miniforge3/envs/cloe-org-env-v2026.1/lib/python3.12/site-packages/cloelib/summary_statistics/angular_two_point.py:407: RuntimeWarning: invalid value encountered in matmul\n",
-      "  mixing_matrix[(\"POS\", \"SHE\", a, b)]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cells_PP = twopoint_pospos.get_pseudo_Cl(0, perturbations.k,mixmats_example)\n",
     "cells_SS = twopoint_sheshe.get_pseudo_Cl(nl, perturbations.k,mixmats_example)\n",
@@ -548,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -615,7 +550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -685,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -728,16 +663,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x37c3ddee0>"
+       "<matplotlib.legend.Legend at 0x3a5a3b8f0>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -769,7 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -791,16 +726,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x37a1bfad0>"
+       "<matplotlib.legend.Legend at 0x38ecb7080>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -832,7 +767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,16 +788,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x39964bfb0>"
+       "<matplotlib.legend.Legend at 0x3a39e6f30>"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -893,16 +828,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x3946de000>"
+       "<matplotlib.legend.Legend at 0x3a26d2480>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -947,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -969,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1006,7 +941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1033,7 +968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,14 +979,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/b1/qymrqldd3fdbp79s76djm9240000gn/T/ipykernel_85065/995855707.py:6: UserWarning: marker is redundantly defined by the 'marker' keyword argument and the fmt string \"o-\" (-> marker='o'). The keyword argument will take precedence.\n",
+      "/var/folders/gv/sp46wltj1716dthc25bf4xjw0000gn/T/ipykernel_43668/995855707.py:6: UserWarning: marker is redundantly defined by the 'marker' keyword argument and the fmt string \"o-\" (-> marker='o'). The keyword argument will take precedence.\n",
       "  ax.plot(\n"
      ]
     },
@@ -1109,7 +1044,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cloe-org-env-v2026.1",
+   "display_name": "cloe_update",
    "language": "python",
    "name": "python3"
   },
@@ -1123,7 +1058,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## 📌 Related Issue
<!-- Link to the issue this PR is addressing, e.g., "Closes #42" -->
Closes #127 

## ✨ What’s been added or changed?
<!-- Summarize the key changes or features introduced in this PR -->
Added `width_pos_i` and `width_shear_i` to the nuisance parameters in `photo.ipynb`.

## 🧪 How was it tested?
<!-- Describe how you verified the change works (unit tests, notebooks, CLI runs, etc.) -->
- notebook runs smoothly locally

## 📸 Screenshots (if applicable)
<!-- Add before/after screenshots or logs if the changes affect the UI or output -->

## 🧠 Anything to keep in mind?
<!-- Note anything relevant like known issues, limitations, or design decisions -->

## 🔍 Checklist
<!-- Check off what you've done before submitting the PR -->
**You can review this PR in ReviewNB, don't forget to log in with your GitHub username**:  
👉 https://app.reviewnb.com/cloe-org/playground/pulls/

- [x] I've named the title of this pull request starting by 'gh-#: TITLE'
- [x] I’ve linked the related issue  
- [x] I’ve tested the code or notebooks manually  
- [ ] I’ve added comments/docstrings where needed (i.e: README)
- [ ] I’ve updated relevant docs if necessary  
