### PR TITLE
gh-150: add necessary default_pars to photometric_likelihoods

### DIFF
--- a/tutorials/likelihood/photometric_likelihoods.ipynb
+++ b/tutorials/likelihood/photometric_likelihoods.ipynb
@@ -414,7 +414,13 @@
     "                'multiplicative_bias_5': 0.0, 'multiplicative_bias_6': 0.0,\n",
     "                'dz_shear_1': 0.0, 'dz_shear_2': 0.0,\n",
     "                'dz_shear_3': 0.0, 'dz_shear_4': 0.0,\n",
-    "                'dz_shear_5': 0.0, 'dz_shear_6': 0.0}"
+    "                'dz_shear_5': 0.0, 'dz_shear_6': 0.0,\n",
+    "                'width_shear_1': 1.0, 'width_shear_2': 1.0,\n",
+    "                'width_shear_3': 1.0, 'width_shear_4': 1.0,\n",
+    "                'width_shear_5': 1.0, 'width_shear_6': 1.0,\n",
+    "                'width_pos_1': 1.0, 'width_pos_2': 1.0,\n",
+    "                'width_pos_3': 1.0, 'width_pos_4': 1.0,\n",
+    "                'width_pos_5': 1.0, 'width_pos_6': 1.0}"
    ]
   },
   {


### PR DESCRIPTION
## 📌 Related Issue
<!-- Link to the issue this PR is addressing, e.g., "Closes #42" -->
Closes #150 

## ✨ What’s been added or changed?
<!-- Summarize the key changes or features introduced in this PR -->
- added missing `width_shear` and `width_pos` default_pars (6 each) to `photometric_likelihoods.ipynb` tutorial

## 🧪 How was it tested?
<!-- Describe how you verified the change works (unit tests, notebooks, CLI runs, etc.) -->
- notebook now runs successfully without KeyErrors

## 📸 Screenshots (if applicable)
<!-- Add before/after screenshots or logs if the changes affect the UI or output -->

## 🧠 Anything to keep in mind?
<!-- Note anything relevant like known issues, limitations, or design decisions -->

## 🔍 Checklist
<!-- Check off what you've done before submitting the PR -->
**You can review this PR in ReviewNB, don't forget to log in with your GitHub username**:  
👉 https://app.reviewnb.com/cloe-org/playground/pulls/

- [x] I've named the title of this pull request starting by 'gh-#: TITLE'
- [x] I’ve linked the related issue  
- [x] I’ve tested the code or notebooks manually  
- [ ] I’ve added comments/docstrings where needed (i.e: README)
- [ ] I’ve updated relevant docs if necessary  
